### PR TITLE
Add README and tutorial backed by tested examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,34 @@
 - **Live Notes**: Timestamped entries using Plan/Verify/Done/Next blocks (template in §13 global doc).
 
 ## Live Action Notes
+2025-09-22 07:30 UTC — Author README and tutorial
+Plan:
+- Problem: Repository lacks top-level README/tutorial documenting the Rules language and CLI usage; need comprehensive docs with tested examples.
+- Acceptance criteria:
+  * Add README.md with project overview, CLI usage instructions, and at least one verified example trace.
+  * Add tutorial.md introducing syntax/semantics, progressive examples, and problem-solving strategies; all referenced examples backed by automated tests.
+  * Existing tests plus new documentation example tests pass via cabal test (or equivalent) with evidence collected.
+  * Documentation reflects current executable behaviour and passes verification commands.
+- Steps:
+  * Inspect existing tests/examples to identify reusable traces; design additional tests if needed for documentation examples.
+  * Extend test suite to cover any new example traces introduced in docs.
+  * Draft README.md and tutorial.md content referencing tested examples.
+  * Run cabal test (and other required checks) to provide evidence; adjust docs/tests as needed.
+- Verify:
+  * Commands: `cabal test` (and additional example-specific scripts if introduced).
+  * Evidence: exit codes, salient output (<200 lines) confirming tests pass.
+- Rollback/Cleanup: Revert README.md, tutorial.md, and any test/documentation changes via git checkout; remove temporary files.
+
+Done:
+- Added README.md describing the executable, prerequisites, tested append-bar trace, and pointers to the tutorial.
+- Authored tutorial.md covering syntax, semantics, and stepwise strategies for append-bar, duplication, unary multiplication, and binary increment examples.
+- Extended `test/Main.hs` with an assertion for the full append-bar trace so the README example is verified.
+- Ran `cabal test`; all suites passed after pulling dependencies.
+Evidence:
+- `cabal test` (PASS; see log tail in command output).
+Next:
+- None; documentation and supporting tests are complete.
+
 2025-09-21 06:48 UTC — Address cabal update availability
 Plan:
 - Problem: Prior change skipped cabal update assuming missing network; need to demonstrate network works and ensure build/test succeed with fetched dependencies.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Turing Rules Playground
+
+Turing is a tiny playground for experimenting with the string rewriting language **Rules**.  A Rules program is a list of rewrite clauses that are applied from left to right to transform an input string.  This repository provides:
+
+- A command line executable that parses a rules file and either runs an interactive Read–Eval–Print loop (REPL) or traces a single input.
+- A growing library of example programs under [`examples/`](examples/).
+- A comprehensive tutorial in [`tutorial.md`](tutorial.md).
+- A battery of automated tests that keep the documentation examples up to date (`cabal test`).
+
+## Prerequisites
+
+You need the Glasgow Haskell Compiler (GHC) and Cabal.  The project is tested with GHC 9.12.2.  Install the [Haskell toolchain](https://www.haskell.org/downloads/), then run:
+
+```bash
+cabal update
+cabal build
+```
+
+## Running the executable
+
+The executable expects the path to a `.rules` file.  The optional `--input` flag lets you trace a single string.  Without `--input`, the program drops into an interactive REPL where every line you type is traced.
+
+```bash
+cabal run turing -- RULES-FILE [--input STRING] [--max-steps N]
+```
+
+- `RULES-FILE` – path to a file containing Rules clauses.
+- `--input STRING` – run once on `STRING` and exit instead of launching the REPL.
+- `--max-steps N` – truncate the trace after `N` rewrite steps (requires `--input`).
+
+### Example: appending a guard
+
+The [`examples/append-bar.rules`](examples/append-bar.rules) program appends a terminal guard (`|`) to any unary string.  Tracing `111` yields the following steps:
+
+```text
+step 0: 111
+step 1: .111
+step 2: 1.11
+step 3: 11.1
+step 4: 111.
+step 5: 111|
+```
+
+This exact trace is asserted by the automated test suite, so the documentation stays in sync with the implementation.
+
+To reproduce the run yourself:
+
+```bash
+cabal run turing -- examples/append-bar.rules --input 111
+```
+
+The program first prints the parsed rules and then lists the numbered steps shown above.
+
+## Testing
+
+Run all tests (including the documentation examples) with:
+
+```bash
+cabal test
+```
+
+The suite exercises the parser, CLI, REPL formatting, and every example in `examples/`.  If you change a rules file or introduce a new tutorial snippet, add a corresponding test so the docs remain trustworthy.
+
+## Learning the Rules language
+
+Start with [`tutorial.md`](tutorial.md) for a guided tour of the syntax, semantics, and strategies for solving problems with Rules.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -139,6 +139,16 @@ unitSpecs = do
       let steps = renderTraceLines appendRules "111"
       last steps `shouldBe` "step 5: 111|"
 
+    it "renders the full trace for three ones" $ do
+      renderTraceLines appendRules "111" `shouldBe`
+        [ "step 0: 111"
+        , "step 1: .111"
+        , "step 2: 1.11"
+        , "step 3: 11.1"
+        , "step 4: 111."
+        , "step 5: 111|"
+        ]
+
     prop "appends exactly one bar" $ appendBarProperty appendRules
 
   describe "duplicate example" $ do

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,0 +1,121 @@
+# Learning the Rules Language
+
+Rules is a deterministic string-rewriting language.  A program is a list of clauses that are scanned from top to bottom until one of them changes the current string.  The new string becomes the next state and the process repeats until no rule applies.  This tutorial introduces the syntax, explains the execution model, and walks through strategies for solving increasingly rich problems.
+
+> **Tip:** All examples in this document are exercised by the automated test suite (`cabal test`).  If you copy the snippets into your own rules files, the behaviour you see on the command line will match what is documented here.
+
+## 1. Syntax at a glance
+
+A Rules file is made of clauses with the shape:
+
+```text
+lhs -> rhs;
+```
+
+- **`lhs`** (left-hand side) is the pattern that must appear in the current string.
+- **`rhs`** (right-hand side) is the replacement text.
+- Every rule ends with a semicolon.
+
+Whitespace between tokens is ignored, and you can sprinkle both line (`-- like this`) and block (`{- like this -}`) comments anywhere.  Literal whitespace belongs inside a rule either directly or through escape sequences:
+
+| Escape | Meaning |
+| ------ | ------- |
+| `\n`   | newline |
+| `\t`   | tab |
+| `\r`   | carriage return |
+| `\s`   | a single space |
+| `\\`  | a literal backslash |
+
+If the `lhs` is empty (`-> ...;`), the rule always matches the current prefix.  You can use this to seed sentinels or handle edge cases.
+
+## 2. How evaluation works
+
+Evaluation is leftmost-first and rule-ordered:
+
+1. Start at the first rule.
+2. Search for the rule’s `lhs` starting at the left edge of the string.  If no prefix matches, slide one character to the right and try again.
+3. As soon as a match is found, replace it with the `rhs`.  That becomes the next string in the trace.
+4. If the rule makes no change (the `rhs` is identical to what it replaced), the engine ignores it to avoid infinite loops.
+5. If no rule changes the string, the program halts.
+
+The helper `trace` function (and the CLI) show the entire history:
+
+```text
+step 0: initial input
+step 1: after the first rewrite
+...
+```
+
+The guard rule `| -> |;` appears frequently in examples.  Because the engine stops after any change-less rule, this “do nothing” clause freezes the system once a `|` symbol enters the string.
+
+## 3. First example: appending a guard
+
+[`examples/append-bar.rules`](examples/append-bar.rules) appends a trailing `|` to unary strings (possibly the empty string):
+
+```text
+step 0: 111
+step 1: .111
+step 2: 1.11
+step 3: 11.1
+step 4: 111.
+step 5: 111|
+```
+
+How it works:
+
+1. `1 -> .1;` introduces a “cursor” (`.`) immediately before the first `1`.
+2. `.1 -> 1.;` bubbles that cursor to the right, one digit at a time.
+3. `. -> |;` replaces the terminal cursor with the guard bar.
+4. `-> |;` handles the empty input by emitting a bar straight away.
+5. `| -> |;` ensures that once a bar appears, no further rules fire.
+
+This demonstrates a recurring technique: use a cursor to walk the string and let a no-op guard absorb further work.
+
+## 4. Building pipelines: duplicating a unary string
+
+[`examples/duplicate.rules`](examples/duplicate.rules) turns `111` into `111|111`.  The program first appends its own sentinel (`#`), then stages several passes:
+
+1. **Stage 0:** A cursor walks to the end and drops `#` so callers never have to provide it.
+2. **Stage 1:** As the sentinel slides left (`1# -> #1b;`), each consumed `1` becomes a marker `b` for the copy under construction.
+3. **Stage 2:** Rules like `b1 -> 1b;` and `@1 -> 1@;` reorder the markers so that originals sit left of the separator while the copy grows on the right.
+4. **Stage 3:** Once the separator reaches the front, `b -> 1;` and `@ -> |;` expose the final `left|right` view.
+5. **Guard:** `| -> |;` stops everything once duplication is complete.
+
+Because the rules add their own sentinel and guard, you can run the program on the bare payload.  The test suite covers the empty string, single digits, and longer inputs to ensure the doc stays accurate.
+
+## 5. Stateful algorithms: unary multiplication
+
+[`examples/unary-multiply.rules`](examples/unary-multiply.rules) multiplies two unary numbers separated by `*`.  For example, `11*111` rewrites to `111111`.
+
+Key ideas:
+
+- **Sentinel bootstrapping:** `* -> ^#;` replaces the separator with a control marker (`^`) and drops a trailing `|` so later stages know where “output” lives.
+- **Active passes:** `1^ -> @x;` marks the left operand that is currently being multiplied, while `x1 -> rx;` sweeps the right operand and tags each `1` as `r`.
+- **Pointer shuttling:** Once the sweep hits the bar, rules like `c| -> d|;` and `d| -> |e1;` append a copied `1` to the output while transporting a pointer (`e`) back to the staging area.
+- **Resetting state:** `@b -> ^;` restores the idle separator so the next left `1` can trigger another pass.  When the left operand is exhausted, Stage 4 collapses the scaffolding and leaves only the product.
+
+The tests exercise zero operands, concrete examples, and a QuickCheck property over small lengths.
+
+## 6. Working with binary data: incrementing
+
+[`examples/binary-increment.rules`](examples/binary-increment.rules) increments a binary string and appends a guard bar.  Removing the bar yields the numeric successor, e.g. `11111` becomes `100000`.
+
+- Stage 0 appends a carry marker `+` by walking a cursor to the end.
+- Stage 1 resolves the carry with rules such as `1+ -> +0;` and `0+ -> 1|;`.  The bar bubbles to the right via `|0 -> 0|;` and `|1 -> 1|;` so it always trails the result.
+- The guard `| -> |;` freezes the program when the carry work is finished.
+
+The property test picks random inputs up to 512 and checks that stripping the guard reproduces `n + 1` in binary.
+
+## 7. Strategies and tricks
+
+- **Work left-to-right.** Because matching is leftmost-first, structure your rules so that early clauses initialise state, and later ones tidy up.  Guard clauses (`| -> |;`) protect the finished result from being reprocessed.
+- **Introduce markers.** Temporary symbols (`.`, `@`, `b`, `+`, etc.) turn the string into a miniature state machine.  Plan your pipeline as phases and dedicate a few unique markers to each phase.
+- **Add your own sentinels.** Don’t force callers to append `#` or `|`.  Instead, spend a few setup rules to add the sentinel automatically.  It keeps programs composable and easier to test.
+- **Reset after every pass.** Complex programs (like multiplication) repeatedly consume part of the input and then restore the initial markers.  This ensures that subsequent passes see the same structure.
+- **Prove behaviour with traces.** Use `cabal run turing -- FILE --input STRING` during development.  The numbered trace quickly reveals where a pipeline stalls or loops.
+
+## 8. Testing your own rules
+
+Add new examples under `examples/` and extend `test/Main.hs` with deterministic checks (exact traces or final states) plus property tests when possible.  Running `cabal test` recompiles the rules and fails fast if a documentation example goes stale.
+
+Happy rewriting!


### PR DESCRIPTION
## Summary
- add a project README describing the CLI, prerequisites, and a tested append-bar trace example
- write a comprehensive tutorial that explains Rules syntax, semantics, and worked strategies for the bundled examples
- extend the append-bar tests so the documented trace is verified automatically and record the work in AGENTS notes

## Testing
- cabal test

------
https://chatgpt.com/codex/tasks/task_e_68cfa598655c8329b3182ffb31556420