### PR TITLE
Add ternary digit sorter example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,61 @@
 - **Preflight**: `which git || true; git --version || true; which docker || true; docker --version || true; ssh-agent sanity check; ssh -T git@github.com || true`
 - **Verification Template**: Problem · Acceptance criteria · Steps · Evidence · Rollback (per global instructions §0).
 - **Live Notes**: Timestamped entries using Plan/Verify/Done/Next blocks (template in §13 global doc).
+- **Network**: Environment has outbound access—run `cabal update` (succeeds) before blaming offline issues.
 - **Tutorial upkeep**: Whenever new examples or Rules strategies land, update `tutorial.md` and its tests before considering the work done.
 
 ## Live Action Notes
+2025-09-21 09:07 UTC — Reconfirm network access and rerun cabal verification
+Plan:
+- Problem: Previous session assumed offline mode, skipping `cabal update`/build/test. Need to document that network is available and rerun the commands to verify the ternary sorter integration end-to-end.
+- Acceptance criteria:
+  * Mini Index records that network access is available and `cabal update` works.
+  * Execute `cabal update`, `cabal build`, and `cabal test` successfully, capturing evidence per verification protocol.
+  * Live Action Notes capture verification results and next steps once commands finish.
+- Steps:
+  * Update Mini Index with a persistent reminder about network availability.
+  * Run `cabal update` to refresh the Hackage index.
+  * Run `cabal build` and `cabal test`, collecting concise logs.
+  * Summarize outcomes in Live Notes and ensure working tree stays clean.
+Verify:
+- Commands: `cabal update`, `cabal build`, `cabal test` (expect exit 0 with concise output <200 lines each).
+- Evidence: Command exit codes, relevant log tails showing success.
+- Rollback/Cleanup: Revert AGENTS.md changes via `git checkout -- AGENTS.md` if verification fails; investigate build/test regressions before proceeding.
+Done:
+- Mini Index updated with the persistent network reminder.
+- `cabal update` refreshed the Hackage index (index-state 2025-09-21T08:17:23Z).
+- `cabal build` fetched dependencies and built library/exe/tests successfully.
+- `cabal test` ran 35 specs including ternary sort coverage; all passed in 0.05s.
+Evidence:
+- `cabal update` (exit 0; index-state 2025-09-21T08:17:23Z).
+- `cabal build` (exit 0; downloaded deps, built lib/exe/tests).
+- `cabal test` (exit 0; 35 specs OK in 0.05s).
+Next:
+- None; verification complete.
+
+2025-09-23 08:30 UTC — Author ternary digit sorting example
+Plan:
+- Problem: Repository needs a new example that explores permutation-style rewriting distinct from existing arithmetic-focused cases. We'll design a ruleset that bubble-sorts ternary digits (`0`, `1`, `2`) and document/test it.
+- Acceptance criteria:
+  * Add `examples/ternary-sort.rules` implementing a terminating rewrite system that sorts any string of `0`, `1`, `2` into nondecreasing order.
+  * Extend `test/Main.hs` with property-based coverage ensuring traces reach a sorted permutation matching multiset counts.
+  * Update `tutorial.md` with an explanation and verified trace for the ternary sorter, keeping docs/tests aligned.
+  * `cabal build` and `cabal test` succeed; evidence bundle recorded per verification plan.
+- Steps:
+  * Prototype swap-based rules on scratch inputs via existing CLI or mental simulation, encode them in a new rules file.
+  * Augment tests to load the new rules and assert deterministic sorted outputs (including QuickCheck property for arbitrary short inputs).
+  * Document the example in the tutorial with a trace snippet referencing the tested behaviour.
+  * Run verification commands, capture outputs, ensure working tree clean post-commit.
+Verify:
+- Commands: `cabal build`, `cabal test`, plus a manual `cabal run turing -- examples/ternary-sort.rules --input 210201` trace capture if feasible.
+- Evidence: exit codes (0), trimmed command output (<200 lines), note of manual trace final state.
+- Rollback/Cleanup: `git checkout -- examples/ternary-sort.rules test/Main.hs tutorial.md` and revert AGENTS entry; `git clean -fd` if needed.
+Done:
+- Added ternary bubble-sort rules, documentation, and tests; confirmed expected trace and random cases via a Python simulator since `cabal build/test` could not resolve dependencies offline.
+- `cabal build` / `cabal test` attempted but blocked by missing Hackage index (network timeout); captured failures plus Ctrl-C after `cabal update` hang.
+Next:
+- Re-run `cabal update`, `cabal build`, and `cabal test` once package index becomes reachable to double-check the integrated suite.
+
 2025-09-21 07:53 UTC — Merge tutorial branch and expand guide
 Plan:
 - Problem: Integrate `codex/create-readme-and-tutorial-for-rules-programming` into `main` and uplift the tutorial so it showcases the current library of Rules examples, guiding readers from basics to advanced strategies.

--- a/examples/ternary-sort.rules
+++ b/examples/ternary-sort.rules
@@ -1,0 +1,5 @@
+-- Bubble-sort ternary digits into nondecreasing order.
+-- Rules swap out-of-order adjacent digits and stop once fully sorted.
+21 -> 12;
+20 -> 02;
+10 -> 01;

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,6 +9,7 @@ import           Test.Tasty       (defaultMain, testGroup)
 import           Test.Tasty.Hspec (testSpec)
 
 import           Data.Char        (intToDigit)
+import           Data.List        (sort)
 import           Data.Text        (Text)
 import qualified Data.Text        as T
 import qualified Data.Text.IO     as TIO
@@ -21,7 +22,8 @@ import           Turing.CLI       (Options (..), parserInfo)
 
 import           Options.Applicative (ParserResult (..), defaultPrefs,
                                       execParserPure)
-import           Test.QuickCheck (Property, (===), chooseInt, forAll)
+import           Test.QuickCheck (Property, (===), chooseInt, elements, forAll,
+                                  vectorOf)
 
 main :: IO ()
 main = do
@@ -257,6 +259,35 @@ unitSpecs = do
 
     prop "matches unary length for values up to 63" $ binaryToUnaryProperty binaryRules
 
+  describe "ternary sort example" $ do
+    ternaryRules <- runIO $ do
+      contents <- TIO.readFile "examples/ternary-sort.rules"
+      case parseRules contents of
+        Left err    -> fail ("failed to parse ternary-sort.rules: " <> T.unpack err)
+        Right rules -> pure rules
+
+    let finalSort input = last (trace ternaryRules input)
+
+    it "sorts documented samples" $ do
+      finalSort "" `shouldBe` ""
+      finalSort "2" `shouldBe` "2"
+      finalSort "210201" `shouldBe` "001122"
+
+    it "produces the expected trace for 210201" $ do
+      renderTraceLines ternaryRules "210201" `shouldBe`
+        [ "step 0: 210201"
+        , "step 1: 120201"
+        , "step 2: 102201"
+        , "step 3: 102021"
+        , "step 4: 102012"
+        , "step 5: 100212"
+        , "step 6: 100122"
+        , "step 7: 010122"
+        , "step 8: 001122"
+        ]
+
+    prop "sorts arbitrary ternary strings" $ ternarySortProperty ternaryRules
+
   where
     duplicateProperty :: Rules Char -> Property
     duplicateProperty rules =
@@ -309,6 +340,15 @@ unitSpecs = do
            let input  = toBinary n
                output = stripGuard (last (trace rules input))
            in output === replicate n '1'
+
+    ternarySortProperty :: Rules Char -> Property
+    ternarySortProperty rules =
+      let maxLen = 6
+      in forAll (chooseInt (0, maxLen)) $ \len ->
+           forAll (vectorOf len (elements "012")) $ \digits ->
+             let input  = digits
+                 output = last (trace rules input)
+             in output === sort input
 
 rulesToTuples :: Rules Char -> [([Char], [Char])]
 rulesToTuples = fmap $ \(Rule lhs rhs) -> (lhs, rhs)

--- a/tutorial.md
+++ b/tutorial.md
@@ -147,7 +147,33 @@ You can combine this with the previous section to build round-trips. For example
 
 The property test picks random inputs up to 512 and checks that stripping the guard reproduces `n + 1` in binary. Chaining this example after the unary→binary conversion and before the binary→unary lookup yields a complete "add one" pipeline on unary inputs.
 
-## 9. Composition Playbook
+## 9. Permutation Mechanics: Sorting Ternary Digits
+
+[`examples/ternary-sort.rules`](examples/ternary-sort.rules) shows that Rules can do more than arithmetic. The program repeatedly swaps out-of-order neighbours so any string over `0`, `1`, and `2` settles into nondecreasing order.
+
+```text
+21 -> 12;
+20 -> 02;
+10 -> 01;
+```
+
+Because the engine is deterministic and always rewrites the leftmost match, these three clauses behave exactly like a bubble sort: every swap removes one inversion, and once none remain the program halts. Here is the full trace for `210201`:
+
+```text
+step 0: 210201
+step 1: 120201
+step 2: 102201
+step 3: 102021
+step 4: 102012
+step 5: 100212
+step 6: 100122
+step 7: 010122
+step 8: 001122
+```
+
+The test suite loads the same rules, asserts this trace verbatim, and adds a QuickCheck property that generates random ternary strings (up to length six) and confirms the final state equals `sort input`. This gives you a reusable pattern for any permutation logic: specify pairwise swaps and rely on monotone progress to guarantee termination.
+
+## 10. Composition Playbook
 
 Once you trust the building blocks above, try combining them:
 
@@ -155,7 +181,7 @@ Once you trust the building blocks above, try combining them:
 - **Trace debugging:** Use `cabal run turing -- FILE --input STRING --max-steps N` to cap runaway traces while you experiment with new compositions.
 - **Property checks everywhere:** Every time you document a behaviour, add a deterministic assertion and a QuickCheck property in `test/Main.hs`. That way the docs and programs evolve together.
 
-## 10. Strategies and Tricks
+## 11. Strategies and Tricks
 
 - **Work left-to-right.** Because matching is leftmost-first, structure your rules so early clauses initialise state and later ones tidy up. Guard clauses (`| -> |;`) protect finished results from being reprocessed.
 - **Introduce markers.** Temporary symbols (`.`, `@`, `b`, `+`, `g`, etc.) turn the string into a miniature state machine. Plan your pipeline as phases and dedicate a few unique markers to each phase.
@@ -164,7 +190,7 @@ Once you trust the building blocks above, try combining them:
 - **Prove behaviour with traces.** Use `cabal run turing -- FILE --input STRING` while developing. The numbered trace quickly reveals where a pipeline stalls or loops.
 - **Document what you learn.** When you discover a new trick or marker pattern, add a short note to this tutorial and cover it with a test. Future you (and teammates) will thank you.
 
-## 11. Verifying and Iterating
+## 12. Verifying and Iterating
 
 Add new examples under `examples/` and extend `test/Main.hs` with deterministic checks (exact traces or final states) plus property tests when possible. Running `cabal test` recompiles the rules and fails fast if a documentation example goes stale.
 
@@ -183,7 +209,7 @@ When you add new behaviours:
 2. Capture the final state (or trace) in a unit test so the documentation can never drift.
 3. Note any reusable insights in `AGENTS.md` so the next change starts from a stronger baseline.
 
-## 12. What to Try Next
+## 13. What to Try Next
 
 - Implement unary addition that reuses the duplication pipeline as a subroutine.
 - Extend the binary lookup table to cover wider inputs or derive it programmatically from a helper script.


### PR DESCRIPTION
## Summary
- add a ternary digit sorting ruleset that bubble-sorts digits in nondecreasing order
- extend the test suite with deterministic trace checks and a QuickCheck property for the new example
- document the permutation-based strategy in the tutorial and record verification notes in AGENTS, now including the successful cabal run with a network reminder

## Testing
- `cabal update`
- `cabal build`
- `cabal test`


------
https://chatgpt.com/codex/tasks/task_e_68cfb3bea9888329879dc0f74ef97973