### PR TITLE
feat: reload rules in repl

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,6 +2,7 @@
 
 module Main (main) where
 
+import           Data.Text      (Text)
 import qualified Data.Text.IO   as T
 import           Rewrite        (Rules)
 import           Rewrite.Parser (parseRules)
@@ -26,7 +27,12 @@ processFile opts = do
       printRules rules
       case inputString opts of
         Just input -> runTraceOnce rules (maxSteps opts) input
-        Nothing    -> runRepl rules
+        Nothing    -> runRepl (reloadAction opts) rules
 
 printRules :: Rules Char -> IO ()
 printRules rules = print rules
+
+reloadAction :: Options -> IO (Either Text (Rules Char))
+reloadAction opts = do
+  contents <- T.readFile (rulesFile opts)
+  pure (parseRules contents)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -17,7 +17,8 @@ import           Numeric          (showIntAtBase)
 
 import           Rewrite          (Rule (..), Rules, trace)
 import           Rewrite.Parser   (parseRules)
-import           Rewrite.Repl     (renderTraceLines, renderTraceLinesLimited)
+import           Rewrite.Repl     (isReloadCommand, renderTraceLines,
+                                   renderTraceLinesLimited)
 import           Turing.CLI       (Options (..), parserInfo)
 
 import           Options.Applicative (ParserResult (..), defaultPrefs,
@@ -124,6 +125,13 @@ unitSpecs = do
       let rules = [Rule "a" "aa"]
       take 3 (renderTraceLinesLimited Nothing rules "a") `shouldBe`
         take 3 (renderTraceLines rules "a")
+
+  describe "isReloadCommand" $ do
+    it "recognizes Ctrl-R" $ do
+      isReloadCommand "\x12" `shouldBe` True
+
+    it "ignores other input" $ do
+      isReloadCommand "abc" `shouldBe` False
 
   describe "append-bar example" $ do
     appendRules <- runIO $ do


### PR DESCRIPTION
## Summary
- add an `isReloadCommand` helper and reuse current rules via an `IORef` so the REPL can reload its rules at runtime
- wire the executable to pass a reload action that reparses the source file and reuse it when Ctrl-R (or :reload) is entered
- cover the new helper with unit tests to lock in the Ctrl-R detection behaviour

## Testing
- `cabal test`
- `cabal run turing -- /tmp/reload.rules`
- `cabal run turing -- /tmp/reload.rules`


------
https://chatgpt.com/codex/tasks/task_e_68d1967eb85083298147c431a5507597